### PR TITLE
Add PlayerAgent basic integration

### DIFF
--- a/scenes/Main.gd
+++ b/scenes/Main.gd
@@ -9,6 +9,8 @@ const MONTH_NAMES := ["Jan","Fev","Mar","Abr","Mai","Jun","Jul","Ago","Set","Out
 #  VARIÁVEIS DE ESTADO
 # =====================================
 var time_running := true
+var player_agent: PlayerAgent = null
+var current_phase: int = 1  # 1 = Agente, 2 = Presidente
 
 # =====================================
 #  NÓS DO JOGO
@@ -34,13 +36,15 @@ var time_running := true
 #  READY
 # =====================================
 func _ready() -> void:
-	print("=== INICIANDO JOGO ===")
-	
-	_setup_timer()
-	_setup_ui_styles()
-	_connect_ui_buttons()
-	_setup_country_clicks()
-	_update_ui()
+        print("=== INICIANDO JOGO ===")
+
+        _setup_timer()
+        _setup_ui_styles()
+        _connect_ui_buttons()
+        _setup_country_clicks()
+
+        _init_player_agent()
+        _update_ui()
 	
 	print("Date Label: ", date_label != null)
 	print("Money Label: ", money_label != null)
@@ -132,8 +136,8 @@ func _setup_timer() -> void:
 	auto_timer.start()
 
 func _connect_ui_buttons() -> void:
-	if pause_button:
-		pause_button.text = "⏸ Pausar"
+        if pause_button:
+                pause_button.text = "⏸ Pausar"
 		pause_button.add_theme_font_size_override("font_size", 16)
 		pause_button.custom_minimum_size = Vector2(120, 40)
 		if not pause_button.pressed.is_connected(_on_pause_pressed):
@@ -143,8 +147,34 @@ func _connect_ui_buttons() -> void:
 		next_button.text = "▶️ Próximo Mês"
 		next_button.add_theme_font_size_override("font_size", 16)
 		next_button.custom_minimum_size = Vector2(150, 40)
-		if not next_button.pressed.is_connected(_on_next_month_pressed):
-			next_button.pressed.connect(_on_next_month_pressed)
+                if not next_button.pressed.is_connected(_on_next_month_pressed):
+                        next_button.pressed.connect(_on_next_month_pressed)
+
+func _init_player_agent():
+        player_agent = PlayerAgent.new()
+        player_agent.name = "Test Agent"
+        player_agent.country = "Argentina"
+        player_agent.background = "Intelectual"
+        player_agent.ideology = "Social-Democrata"
+        player_agent.charisma = 60
+        player_agent.intelligence = 70
+        player_agent.connections = 50
+        player_agent.wealth = 40
+        player_agent.military_knowledge = 30
+
+        player_agent.support = {
+                "military": 20,
+                "business": 25,
+                "intellectuals": 45,
+                "workers": 35,
+                "students": 40,
+                "church": 15,
+                "peasants": 20
+        }
+
+        Globals.player_country = player_agent.country
+
+        print("👤 Agente político criado: %s" % player_agent.name)
 
 # =====================================
 #  CLIQUES NO MAPA
@@ -197,11 +227,14 @@ func _on_next_month_pressed() -> void:
 		_advance_month()
 
 func _advance_month() -> void:
-	# Avançar tempo global
-	Globals.current_month += 1
-	if Globals.current_month > 12:
-		Globals.current_month = 1
-		Globals.current_year += 1
+        # Avançar tempo global
+        Globals.current_month += 1
+        if Globals.current_month > 12:
+                Globals.current_month = 1
+                Globals.current_year += 1
+
+        if current_phase == 1 and player_agent:
+                _advance_agent_month()
 
 	# Simulação passiva de todos os países
 	Globals.simulate_monthly_changes()
@@ -231,26 +264,38 @@ func _advance_month() -> void:
 #  UI REFRESH
 # =====================================
 func _update_ui() -> void:
-	# Dados do jogador atual
-	var player_data = Globals.get_player_data()
-	
-	if date_label:
-		date_label.text = "%s %d" % [MONTH_NAMES[Globals.current_month - 1], Globals.current_year]
-		date_label.add_theme_font_size_override("font_size", 18)
-		date_label.add_theme_color_override("font_color", Color.WHITE)
-	
-	if money_label:
-		var money = player_data.get("money", 0)
-		money_label.text = "$ %s" % _format_number(money)
-		money_label.add_theme_font_size_override("font_size", 18)
-		money_label.add_theme_color_override("font_color", Color.GREEN)
+        var money = 0
+        var stability = 50
+        var additional_info = ""
 
-	if stability_label:
-		var stability = player_data.get("stability", 50)
-		stability_label.text = "Estabilidade: %d%%" % stability
-		stability_label.add_theme_font_size_override("font_size", 18)
-		var col: Color = Color.GREEN if stability > 70 else (Color.YELLOW if stability > 40 else Color.RED)
-		stability_label.add_theme_color_override("font_color", col)
+        if current_phase == 1 and player_agent:
+                money = player_agent.wealth * 100
+                stability = player_agent.get_total_support() / 7
+                additional_info = " (%s)" % player_agent.current_position
+        else:
+                var player_data = Globals.get_player_data()
+                money = player_data.get("money", 0)
+                stability = player_data.get("stability", 50)
+
+        if date_label and date_label is Label:
+                date_label.text = "%s %d" % [MONTH_NAMES[Globals.current_month - 1], Globals.current_year]
+                date_label.add_theme_color_override("font_color", Color.WHITE)
+
+        if money_label and money_label is Label:
+                if current_phase == 1:
+                        money_label.text = "💰 Recursos: %d" % money
+                else:
+                        money_label.text = "$ %s" % _format_number(money)
+                money_label.add_theme_color_override("font_color", Color.GREEN)
+
+        if stability_label and stability_label is Label:
+                if current_phase == 1:
+                        stability_label.text = "📊 Apoio: %d%%%s" % [stability, additional_info]
+                else:
+                        stability_label.text = "Estabilidade: %d%%" % stability
+
+                var color = Color.GREEN if stability > 70 else (Color.YELLOW if stability > 40 else Color.RED)
+                stability_label.add_theme_color_override("font_color", color)
 
 # Formatar números grandes
 func _format_number(num: int) -> String:
@@ -625,11 +670,29 @@ func _input(event: InputEvent) -> void:
 		# Carregar jogo
 		Globals.load_game_data()
 		_update_ui()
-	elif event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
-		# Detecta cliques em polígonos do mapa
-		var country_name = _detect_polygon_click(event.global_position)
-		if country_name != "":
-			_show_country_info(country_name)
+        elif event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+                # Detecta cliques em polígonos do mapa
+                var country_name = _detect_polygon_click(event.global_position)
+                if country_name != "":
+                        _show_country_info(country_name)
+        if OS.is_debug_build() and event is InputEventKey and event.pressed:
+                match event.keycode:
+                        KEY_F1:
+                                if player_agent:
+                                        player_agent.current_position = "Presidente"
+                                        _transition_to_phase_2()
+                        KEY_F2:
+                                if player_agent:
+                                        print("=== AGENTE DEBUG ===")
+                                        print("Nome: %s" % player_agent.name)
+                                        print("Posição: %s" % player_agent.current_position)
+                                        print("Apoio Total: %d/700" % player_agent.get_total_support())
+                                        print("Fase: %d" % current_phase)
+                        KEY_F3:
+                                if player_agent and current_phase == 1:
+                                        for group in player_agent.support:
+                                                player_agent.support[group] = min(100, player_agent.support[group] + 10)
+                                        print("📈 Apoio aumentado!")
 
 # =====================================
 #  AÇÕES DO PAÍS DO JOGADOR
@@ -702,8 +765,8 @@ func _on_trade_with_country(country_name: String) -> void:
 	_show_country_info(country_name)
 
 func _on_spy_country(country_name: String) -> void:
-	print("Espiando: ", country_name)
-	Globals.adjust_country_value(Globals.player_country, "money", -300)
+        print("Espiando: ", country_name)
+        Globals.adjust_country_value(Globals.player_country, "money", -300)
 	
 	# Chance de descobrir informações valiosas
 	if randi() % 100 < 30:  # 30% de chance
@@ -717,7 +780,82 @@ func _on_spy_country(country_name: String) -> void:
 		print("Espionagem foi descoberta!")
 	
 	_update_ui()
-	_show_country_info(country_name)
+        _show_country_info(country_name)
+
+func _advance_agent_month():
+        player_agent.political_experience += 1
+
+        if randi() % 100 < 30:
+                var groups = player_agent.support.keys()
+                var random_group = groups[randi() % groups.size()]
+                var gain = randi_range(1, 5)
+                player_agent.support[random_group] = min(100, player_agent.support[random_group] + gain)
+                print("📈 Ganhou %d de apoio com %s" % [gain, random_group])
+
+        _check_position_advancement()
+
+func _check_position_advancement():
+        if not player_agent:
+                return
+
+        var total_support = player_agent.get_total_support()
+        var old_position = player_agent.current_position
+        var advanced = false
+
+        match player_agent.current_position:
+                "Cidad\u00e3o":
+                        if total_support >= 50:
+                                player_agent.current_position = "Ativista"
+                                advanced = true
+                "Ativista":
+                        if total_support >= 100:
+                                player_agent.current_position = "Deputado"
+                                advanced = true
+                "Deputado":
+                        if total_support >= 150:
+                                player_agent.current_position = "Senador"
+                                advanced = true
+                "Senador":
+                        if total_support >= 200:
+                                player_agent.current_position = "Ministro"
+                                advanced = true
+                "Ministro":
+                        if total_support >= 250:
+                                player_agent.current_position = "Presidente"
+                                advanced = true
+                                _transition_to_phase_2()
+
+        if advanced:
+                print("🎖️ %s avançou de %s para %s!" % [player_agent.name, old_position, player_agent.current_position])
+                _show_advancement_popup(old_position, player_agent.current_position)
+
+func _transition_to_phase_2():
+        print("🏛️ TRANSIÇÃO PARA FASE 2: PRESIDENTE!")
+        current_phase = 2
+
+        var stability_bonus = (player_agent.get_total_support() - 175) / 5
+        var money_bonus = player_agent.wealth * 1000
+
+        Globals.adjust_country_value(player_agent.country, "stability", stability_bonus)
+        Globals.adjust_country_value(player_agent.country, "money", money_bonus)
+
+        _show_presidency_popup()
+
+func _show_advancement_popup(old_pos: String, new_pos: String):
+        var dialog = AcceptDialog.new()
+        dialog.title = "🎖️ Avanço Político!"
+        dialog.dialog_text = "Parabéns! %s avançou de %s para %s!" % [player_agent.name, old_pos, new_pos]
+        add_child(dialog)
+        dialog.popup_centered()
+        dialog.confirmed.connect(dialog.queue_free)
+
+func _show_presidency_popup():
+        var dialog = AcceptDialog.new()
+        dialog.title = "🏛️ PRESIDENTE ELEITO!"
+        dialog.dialog_text = "🎉 %s conquistou a presidência de %s!\n\nAgora você controla o país diretamente." % [player_agent.name, player_agent.country]
+        add_child(dialog)
+        dialog.popup_centered()
+        dialog.confirmed.connect(dialog.queue_free)
 
 # =====================================
 #  GETTERS - COMPATIBILIDADE COM SISTEMA ANTIGO


### PR DESCRIPTION
## Summary
- create a test `PlayerAgent` when the game starts
- display agent resources and support during phase 1
- progress the agent every month and allow advancement to president
- provide debug hotkeys to quickly test the agent system

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f57067a6c832b8f0c819a5c404f42