### PR TITLE
Implement network reveal logic

### DIFF
--- a/scripts/PartyController.gd
+++ b/scripts/PartyController.gd
@@ -342,10 +342,16 @@ func attempt_network_discovery(network_id: String):
 	party_data.treasury -= cost
 	var success_chance = party_data.influence / 100.0
 	
-	if randf() < success_chance:
-		emit_signal("action_executed", "Investigar Rede", true, "Rede '%s' descoberta com sucesso!" % network_id)
-		# TODO: Adicionar lógica para revelar informações da rede
-	else:
+        if randf() < success_chance:
+                var message := "Rede '%s' descoberta com sucesso!" % network_id
+                if PowerNetworks and PowerNetworks.hidden_networks.has(network_id):
+                        var network = PowerNetworks.hidden_networks[network_id]
+                        network["discovered"] = true
+                        PowerNetworks.hidden_networks[network_id] = network
+                        message = "Rede '%s' descoberta! Membros: %s" % [network["name"], ", ".join(network["members"])]
+                        print("✅ Investigação revelou detalhes da rede '%s'" % network_id)
+                emit_signal("action_executed", "Investigar Rede", true, message)
+        else:
 		emit_signal("action_executed", "Investigar Rede", false, "Investigação não revelou informações úteis sobre '%s'." % network_id)
 
 # =====================================


### PR DESCRIPTION
## Summary
- mark discovered networks when investigations succeed
- show member details in the success message for Investigate Network actions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cca1cf64c832b82e6c958c9c1d3f7